### PR TITLE
Add number entities for supply/exhaust fan speeds

### DIFF
--- a/custom_components/siku/__init__.py
+++ b/custom_components/siku/__init__.py
@@ -16,7 +16,12 @@ from .coordinator import SikuDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[Platform] = [Platform.FAN, Platform.SENSOR, Platform.BUTTON]
+PLATFORMS: list[Platform] = [
+    Platform.FAN,
+    Platform.SENSOR,
+    Platform.BUTTON,
+    Platform.NUMBER,
+]
 
 
 def _legacy_entity_unique_id_to_stable(

--- a/custom_components/siku/api_v2.py
+++ b/custom_components/siku/api_v2.py
@@ -67,6 +67,17 @@ COMMAND_READ_FIRMWARE_VERSION = "86"
 COMMAND_FILTER_ALARM = "88"
 COMMAND_FAN_TYPE = "B9"
 
+# Supply and exhaust fan speed per speed mode, the intake/exhaust balance.
+# Manual speed mode drives both fans from one speed and ignores these.
+PRESET_SPEED_COMMANDS = {
+    "supply_speed_1": "3A",
+    "exhaust_speed_1": "3B",
+    "supply_speed_2": "3C",
+    "exhaust_speed_2": "3D",
+    "supply_speed_3": "3E",
+    "exhaust_speed_3": "3F",
+}
+
 COMMAND_FUNCTION_R = "01"
 COMMAND_FUNCTION_W = "02"
 COMMAND_FUNCTION_RW = "03"
@@ -90,6 +101,9 @@ EMPTY_VALUE = "00"
 
 SPEED_MANUAL_MIN: int = 0
 SPEED_MANUAL_MAX: int = 255
+
+SPEED_PRESET_MIN: int = 10
+SPEED_PRESET_MAX: int = 255
 
 
 class SikuV2Api:
@@ -132,6 +146,7 @@ class SikuV2Api:
             COMMAND_FILTER_TIMER,
             COMMAND_READ_ALARM,
             COMMAND_READ_FIRMWARE_VERSION,
+            *PRESET_SPEED_COMMANDS.values(),
         ]
         cmd = "".join(commands).upper()
         hexlist = await self._send_command(FUNC_READ, cmd)
@@ -169,6 +184,14 @@ class SikuV2Api:
             )
         )
         cmd = f"{COMMAND_SPEED}FF{COMMAND_MANUAL_SPEED}{speed:02X}".upper()
+        await self._send_command(FUNC_READ_WRITE, cmd)
+        return await self.status()
+
+    async def preset_speed(self, key: str, speed: int) -> dict:
+        """Set supply or exhaust fan speed for one of the 3 speed modes."""
+        if not SPEED_PRESET_MIN <= speed <= SPEED_PRESET_MAX:
+            raise ValueError(f"Invalid preset fan speed: {speed}")
+        cmd = f"{PRESET_SPEED_COMMANDS[key]}{speed:02X}".upper()
         await self._send_command(FUNC_READ_WRITE, cmd)
         return await self.status()
 
@@ -456,8 +479,14 @@ class SikuV2Api:
             timer_countdown = int(seconds + minutes * 60 + hours * 60 * 60)
         except KeyError:
             timer_countdown = 0
+        preset_speeds = {
+            key: int(data[cmd], 16)
+            for key, cmd in PRESET_SPEED_COMMANDS.items()
+            if data.get(cmd)
+        }
         return {
             "is_on": is_on,
+            "preset_speeds": preset_speeds,
             "speed": speed,
             "speed_list": FAN_SPEEDS,
             "manual_speed_selected": bool(speed == "255"),

--- a/custom_components/siku/number.py
+++ b/custom_components/siku/number.py
@@ -1,0 +1,80 @@
+"""Siku (Blauberg) Fan numbers."""
+
+from __future__ import annotations
+
+from homeassistant.components.number import (
+    NumberEntity,
+    NumberEntityDescription,
+    NumberMode,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import SikuEntity
+from .api_v2 import PRESET_SPEED_COMMANDS, SPEED_PRESET_MAX, SPEED_PRESET_MIN
+from .const import DOMAIN
+from .coordinator import SikuDataUpdateCoordinator
+
+NUMBERS: tuple[NumberEntityDescription, ...] = tuple(
+    NumberEntityDescription(
+        key=key,
+        name=key.replace("_", " ").capitalize(),
+        entity_category=EntityCategory.CONFIG,
+        native_min_value=SPEED_PRESET_MIN,
+        native_max_value=SPEED_PRESET_MAX,
+        native_step=1,
+        mode=NumberMode.BOX,
+    )
+    for key in PRESET_SPEED_COMMANDS
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Siku (Blauberg) Fan numbers."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    # Only the v2 protocol reports supply/exhaust speeds.
+    preset_speeds = (coordinator.data or {}).get("preset_speeds", {})
+
+    async_add_entities(
+        [
+            SikuNumber(coordinator, description)
+            for description in NUMBERS
+            if description.key in preset_speeds
+        ],
+        True,
+    )
+
+
+class SikuNumber(SikuEntity, NumberEntity):
+    """Representation of a Siku related Number."""
+
+    def __init__(
+        self,
+        coordinator: SikuDataUpdateCoordinator,
+        description: NumberEntityDescription,
+    ) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator=coordinator, context=description.key)
+        self.entity_description = description
+        self._attr_device_info = coordinator.device_info
+        self._attr_unique_id = (
+            f"{DOMAIN}-{coordinator.config_entry.entry_id}-{description.key}"
+        )
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current speed."""
+        return self.coordinator.data["preset_speeds"].get(self.entity_description.key)
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set a new speed."""
+        response = await self.coordinator.api.preset_speed(
+            self.entity_description.key, int(value)
+        )
+        self.coordinator.async_set_updated_data(response)

--- a/tests/test_api_v2.py
+++ b/tests/test_api_v2.py
@@ -3,7 +3,14 @@
 import asyncio
 import pytest
 from unittest.mock import AsyncMock, patch
-from custom_components.siku.api_v2 import SPEED_MANUAL_MAX, SPEED_MANUAL_MIN, SikuV2Api
+from custom_components.siku.api_v2 import (
+    PRESET_SPEED_COMMANDS,
+    SPEED_MANUAL_MAX,
+    SPEED_MANUAL_MIN,
+    SPEED_PRESET_MAX,
+    SPEED_PRESET_MIN,
+    SikuV2Api,
+)
 from custom_components.siku.const import (
     FAN_SPEEDS,
     DIRECTIONS,
@@ -557,3 +564,54 @@ async def test_filter_timer_parse_size5_max(api):
     assert (await api._translate_response(data))[
         "filter_timer_minutes"
     ] == 181 * 24 * 60 + 23 * 60 + 59
+
+
+# --- supply/exhaust fan speeds (the intake/exhaust balance) -----------------
+
+
+@pytest.mark.asyncio
+async def test_preset_speed(api):
+    """The parameter byte is followed by the speed as hex."""
+    with (
+        patch.object(api, "_send_command", new=AsyncMock()) as mock_send,
+        patch.object(
+            api,
+            "status",
+            new=AsyncMock(return_value={"preset_speeds": {"exhaust_speed_1": 39}}),
+        ),
+    ):
+        result = await api.preset_speed("exhaust_speed_1", 39)
+
+        assert mock_send.call_args[0][1] == "3B27"
+        assert result["preset_speeds"]["exhaust_speed_1"] == 39
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("speed", [SPEED_PRESET_MIN - 1, SPEED_PRESET_MAX + 1])
+async def test_preset_speed_out_of_range(api, speed):
+    with (
+        patch.object(api, "_send_command", new=AsyncMock()),
+        pytest.raises(ValueError),
+    ):
+        await api.preset_speed("supply_speed_1", speed)
+
+
+@pytest.mark.asyncio
+async def test_status_reads_preset_speeds(api):
+    with (
+        patch.object(api, "_send_command", new=AsyncMock()) as mock_send,
+        patch.object(api, "_parse_response", new=AsyncMock(return_value={})),
+    ):
+        await api.status()
+
+        for command in PRESET_SPEED_COMMANDS.values():
+            assert command in mock_send.call_args[0][1]
+
+
+@pytest.mark.asyncio
+async def test_preset_speeds_translate(api):
+    """Parameters the fan did not answer are left out."""
+    result = await api._translate_response({"3A": "33", "3B": "27"})
+
+    assert result["preset_speeds"] == {"supply_speed_1": 51, "exhaust_speed_1": 39}
+    assert (await api._translate_response({}))["preset_speeds"] == {}

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,0 +1,51 @@
+"""Tests for SikuNumber entity."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, Mock
+import custom_components.siku.number as number
+
+# ruff: noqa: D103
+
+
+def _coordinator(preset_speeds):
+    coordinator = MagicMock()
+    coordinator.data = {"preset_speeds": preset_speeds}
+    coordinator.api.preset_speed = AsyncMock(return_value={"preset_speeds": {}})
+    return coordinator
+
+
+async def _setup(coordinator):
+    hass = MagicMock()
+    entry = MagicMock()
+    entry.entry_id = "test_entry"
+    hass.data = {number.DOMAIN: {entry.entry_id: coordinator}}
+    async_add_entities = Mock()
+
+    await number.async_setup_entry(hass, entry, async_add_entities)
+    return async_add_entities.call_args[0][0]
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_adds_reported_speeds_only():
+    """Parameters the fan did not answer, and v1 fans, get no entity."""
+    entities = await _setup(_coordinator({"supply_speed_1": 51}))
+
+    assert [entity.entity_description.key for entity in entities] == ["supply_speed_1"]
+    assert isinstance(entities[0], number.SikuNumber)
+
+    coordinator = MagicMock()
+    coordinator.data = None
+    assert await _setup(coordinator) == []
+
+
+@pytest.mark.asyncio
+async def test_native_value_and_set():
+    coordinator = _coordinator({"exhaust_speed_2": 64})
+    entity = (await _setup(coordinator))[0]
+
+    assert entity.native_value == 64
+
+    await entity.async_set_native_value(70.0)
+
+    coordinator.api.preset_speed.assert_awaited_once_with("exhaust_speed_2", 70)
+    coordinator.async_set_updated_data.assert_called_once_with({"preset_speeds": {}})


### PR DESCRIPTION
The v2 protocol has a separate supply and exhaust speed per speed mode (params 0x3A-0x3F), which is the intake/exhaust balance from the vendor app. `status()` now reads them, `preset_speed()` writes one, and the new number platform exposes them for fans that report them.

Only affects speed modes 1/2/3 - manual speed drives both fans from a single value. Tested on three Duka One S6W units.
